### PR TITLE
Mark old docs as old, with a link to latest version

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -25,15 +25,13 @@ jobs:
           sudo apt install -y ruby-bundler ruby-dev
           python3 -m pip install -r requirements.txt
           python3 make_index.py
+      - name: Mark old docs
+        run: python3 mark_old_docs.py
 
       - name: Copy web files into _html folder
         run: |
           mkdir _html
-          cp index.html _html
-          cp -r ufl _html
-          cp -r basix _html
-          cp -r ffcx _html
-          cp -r dolfinx _html
+          cp index.html ufl basix ffcx dolfinx _html
       - name: Upload build as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -64,15 +62,13 @@ jobs:
           sudo apt install -y ruby-bundler ruby-dev
           python3 -m pip install -r requirements.txt
           python3 make_index.py
+      - name: Mark old docs
+        run: python3 mark_old_docs.py
 
       - name: Copy web files into _html folder
         run: |
           mkdir _html
-          cp index.html _html
-          cp -r ufl _html
-          cp -r basix _html
-          cp -r ffcx _html
-          cp -r dolfinx _html
+          cp index.html ufl basix ffcx dolfinx _html
 
       # Deploy to GitHub Pages
       - name: Setup Pages

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Copy web files into _html folder
         run: |
           mkdir _html
-          cp index.html ufl basix ffcx dolfinx _html
+          cp -r index.html ufl basix ffcx dolfinx _html
       - name: Upload build as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -68,7 +68,7 @@ jobs:
       - name: Copy web files into _html folder
         run: |
           mkdir _html
-          cp index.html ufl basix ffcx dolfinx _html
+          cp -r index.html ufl basix ffcx dolfinx _html
 
       # Deploy to GitHub Pages
       - name: Setup Pages

--- a/mark_old_docs.py
+++ b/mark_old_docs.py
@@ -41,12 +41,12 @@ for library in ["ufl", "basix", "ffcx", "dolfinx"]:
 
                     with open(file, "w") as f:
                         f.write(pre)
-                        f.write("\n<!-- Outdated warning -->\n")
+                        f.write("<!-- Outdated warning -->\n")
                         f.write("<div style='width:800px;margin:auto;padding:20px;background-color:white'>")
-                        f.write("<h3 style='color:red'>Note: this is documentation for an old release. "
+                        f.write("<b>Note: this is documentation for an old release. "
                                 "View the latest documentation at "
                                 f"<a href='/{latest_link}'>docs.fenicsproject.org/{latest_link}</a>"
-                                "</h3>")
+                                "</b>")
                         f.write("</div>")
-                        f.write("\n<!-- End outdated warning -->\n")
+                        f.write("\n<!-- End outdated warning -->")
                         f.write(post)

--- a/mark_old_docs.py
+++ b/mark_old_docs.py
@@ -5,7 +5,7 @@ def html_files(folder):
     for file in os.listdir(folder):
         if file.startswith("."):
             continue
-        file_path = os.path.join(folder, file)
+        file_path = f"{folder}/{file}"
         if os.path.isdir(file_path):
             out += html_files(file_path)
         elif file.endswith(".html"):
@@ -14,13 +14,13 @@ def html_files(folder):
 
 for library in ["ufl", "basix", "ffcx", "dolfinx"]:
     latest = max(folder for folder in os.listdir(library)
-                 if os.path.isdir(os.path.join(library, folder)) and folder != "main")
+                 if os.path.isdir(f"{library}/{folder}") and folder != "main")
 
     for folder in os.listdir(library):
         if folder != latest and folder != "main":
-            folder_path = os.path.join(library, folder)
+            folder_path = f"{library}/{folder}"
             if os.path.isdir(folder_path):
-                for file in html_files(os.path.join(library, folder)):
+                for file in html_files(f"{library}/{folder}"):
                     with open(file) as f:
                         content = f.read()
 

--- a/mark_old_docs.py
+++ b/mark_old_docs.py
@@ -1,0 +1,52 @@
+import os
+
+def html_files(folder):
+    out = []
+    for file in os.listdir(folder):
+        if file.startswith("."):
+            continue
+        file_path = os.path.join(folder, file)
+        if os.path.isdir(file_path):
+            out += html_files(file_path)
+        elif file.endswith(".html"):
+            out.append(file_path)
+    return out
+
+for library in ["ufl", "basix", "ffcx", "dolfinx"]:
+    latest = max(folder for folder in os.listdir(library)
+                 if os.path.isdir(os.path.join(library, folder)) and folder != "main")
+
+    for folder in os.listdir(library):
+        if folder != latest and folder != "main":
+            folder_path = os.path.join(library, folder)
+            if os.path.isdir(folder_path):
+                for file in html_files(os.path.join(library, folder)):
+                    with open(file) as f:
+                        content = f.read()
+
+                    if "<!-- Outdated warning -->" in content:
+                        pre, post = content.split("<!-- Outdated warning -->")
+                        _, post = content.split("<!-- End outdated warning -->")
+                    else:
+                        pre, post = content.split("<body")
+                        body_tags, post = post.split(">", 1)
+                        pre = f"{pre}<body{body_tags}>"
+                        assert content == f"{pre}{post}"
+
+                    if os.path.isfile(file.replace(folder, latest)):
+                        latest_link = file.replace(folder, latest)
+                    else:
+                        file_parts = file.split("/")
+                        latest_link = f"{folder}/{latest}/{file_parts[2]}"
+
+                    with open(file, "w") as f:
+                        f.write(pre)
+                        f.write("\n<!-- Outdated warning -->\n")
+                        f.write("<div style='width:800px;margin:auto;padding:20px;background-color:white'>")
+                        f.write("<h3 style='color:red'>Note: this is documentation for an old release. "
+                                "View the latest documentation at "
+                                f"<a href='/{latest_link}'>docs.fenicsproject.org/{latest_link}</a>"
+                                "</h3>")
+                        f.write("</div>")
+                        f.write("\n<!-- End outdated warning -->\n")
+                        f.write(post)


### PR DESCRIPTION
Added a Python script that adds a link like this to all docs except the most recent version and main:

![image](https://github.com/FEniCS/docs/assets/9850599/3828dc39-feeb-40b0-9c2e-cd39905718e7)
