### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -2,7 +2,7 @@ name: Build and deploy website
 
 on:
   push:
-    # branches: [main]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -2,7 +2,7 @@ name: Build and deploy website
 
 on:
   push:
-    branches: [main]
+    # branches: [main]
   pull_request:
     branches: [main]
 

--- a/make_index.py
+++ b/make_index.py
@@ -21,7 +21,7 @@ with open(os.path.join(web_path, "template.md"), "w") as f:
     f.write("\n")
     f.write("!!CONTENT!!\n")
 
-system(f"cd {web_path} && bundle install && bundle exec jekyll build")
+system(f"cd {web_path} && bundle config path ../.bundle-config && bundle install && bundle exec jekyll build")
 
 with open(os.path.join(web_path, "_site/template.html")) as f:
     template = f.read()


### PR DESCRIPTION
Docs haven't been updated with CI runs since Mon, 06 Jan 2025. 

`bundle` command failed with a permission error.  running with `sudo` privileges is discouraged, so a local `.bundle-config` directory is now used for the build. 

TODO: remove testing commit that executes CI on non `main` branches as well.